### PR TITLE
feat: add SIP-013 SFT support

### DIFF
--- a/migrations/1670264425574_smart-contracts.ts
+++ b/migrations/1670264425574_smart-contracts.ts
@@ -31,7 +31,7 @@ export function up(pgm: MigrationBuilder): void {
       notNull: true,
     },
     token_count: {
-      type: 'int',
+      type: 'numeric',
     },
     created_at: {
       type: 'timestamp',

--- a/migrations/1670265062169_tokens.ts
+++ b/migrations/1670265062169_tokens.ts
@@ -20,7 +20,7 @@ export function up(pgm: MigrationBuilder): void {
       notNull: true,
     },
     token_number: {
-      type: 'int',
+      type: 'numeric',
       notNull: true,
     },
     update_mode: {

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -2,6 +2,7 @@ import Fastify, { FastifyPluginAsync } from 'fastify';
 import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { FtRoutes } from './routes/ft';
 import { NftRoutes } from './routes/nft';
+import { SftRoutes } from './routes/sft';
 import { PgStore } from '../pg/pg-store';
 import FastifyCors from '@fastify/cors';
 import FastifySwagger, { SwaggerOptions } from '@fastify/swagger';
@@ -41,6 +42,7 @@ export const Api: FastifyPluginAsync<Record<never, never>, Server, TypeBoxTypePr
 ) => {
   await fastify.register(FtRoutes);
   await fastify.register(NftRoutes);
+  await fastify.register(SftRoutes);
   await fastify.register(StatusRoutes);
 };
 

--- a/src/api/routes/nft.ts
+++ b/src/api/routes/nft.ts
@@ -2,7 +2,7 @@ import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Type } from '@sinclair/typebox';
 import { FastifyPluginCallback } from 'fastify';
 import { Server } from 'http';
-import { Metadata, SmartContractRegEx, TokenQuerystringParams } from '../types';
+import { Metadata, SmartContractRegEx, TokenQuerystringParams, TokenUri } from '../types';
 import { handleTokenCache } from '../util/cache';
 import { parseMetadataLocaleBundle } from '../util/helpers';
 import { generateTokenErrorResponse, TokenErrorResponseSchema } from '../util/errors';
@@ -30,7 +30,7 @@ export const NftRoutes: FastifyPluginCallback<Record<never, never>, Server, Type
         querystring: TokenQuerystringParams,
         response: {
           200: Type.Object({
-            token_uri: Type.Optional(Type.String({ format: 'uri' })),
+            token_uri: Type.Optional(TokenUri),
             metadata: Type.Optional(Metadata),
           }),
           ...TokenErrorResponseSchema,
@@ -39,7 +39,7 @@ export const NftRoutes: FastifyPluginCallback<Record<never, never>, Server, Type
     },
     async (request, reply) => {
       try {
-        const metadataBundle = await fastify.db.getNftMetadataBundle({
+        const metadataBundle = await fastify.db.getTokenMetadataBundle({
           contractPrincipal: request.params.principal,
           tokenNumber: request.params.token_id,
           locale: request.query.locale,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -45,6 +45,12 @@ export const Metadata = Type.Object({
 });
 export type MetadataType = Static<typeof Metadata>;
 
+export const Name = Type.String();
+export const Symbol = Type.String();
+export const Decimals = Type.Integer();
+export const TotalSupply = Type.String();
+export const TokenUri = Type.String({ format: 'uri' });
+
 export const TokenNotFoundResponse = Type.Object({
   error: Type.Literal('Token not found'),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ async function initApp() {
     },
   });
 
-  const jobQueue = new JobQueue({ db });
+  const jobQueue = new JobQueue({ db, apiDb });
   registerShutdownConfig({
     name: 'Job Queue',
     forceKillable: false,

--- a/src/pg/blockchain-api/pg-blockchain-api-store.ts
+++ b/src/pg/blockchain-api/pg-blockchain-api-store.ts
@@ -89,4 +89,17 @@ export class PgBlockchainApiStore extends BasePgStore {
       return result[0];
     }
   }
+
+  getSmartContractLogsByContractCursor(args: {
+    contractId: string;
+  }): AsyncIterable<BlockchainDbContractLog[]> {
+    return this.sql<BlockchainDbContractLog[]>`
+      SELECT contract_identifier, value, sender_address
+      FROM contract_logs
+      WHERE contract_identifier = ${args.contractId}
+        AND canonical = TRUE
+        AND microblock_canonical = TRUE
+      ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+    `.cursor();
+  }
 }

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -99,30 +99,31 @@ export class PgStore extends BasePgStore {
     return result[0].max;
   }
 
-  async updateSmartContractTokenCount(args: { id: number; count: number }): Promise<void> {
+  async updateSmartContractTokenCount(args: { id: number; count: bigint }): Promise<void> {
     await this.sql`
-      UPDATE smart_contracts SET token_count = ${args.count} WHERE id = ${args.id}
+      UPDATE smart_contracts SET token_count = ${args.count.toString()} WHERE id = ${args.id}
     `;
   }
 
   /**
    * Returns a cursor that inserts new tokens and new token queue entries until `token_count` items
-   * are created. A cursor is preferred because `token_count` could be in the tens of thousands.
+   * are created, usually used when processing an NFT contract. A cursor is preferred because
+   * `token_count` could be in the tens of thousands.
    * @param smart_contract_id - smart contract id
    * @param token_count - how many tokens to insert
-   * @param type - token type (ft, nft, sft)
-   * @returns `DbTokenQueueEntry` cursor
+   * @param type - token type
+   * @returns `DbJob` array for all inserted tokens
    */
-  async insertAndEnqueueTokens(args: {
+  async insertAndEnqueueSequentialTokens(args: {
     smart_contract_id: number;
-    token_count: number;
+    token_count: bigint;
     type: DbTokenType;
   }): Promise<DbJob[]> {
     const tokenValues: DbTokenInsert[] = [];
     for (let index = 1; index <= args.token_count; index++) {
       tokenValues.push({
         smart_contract_id: args.smart_contract_id,
-        token_number: index,
+        token_number: index.toString(),
         type: args.type,
       });
     }

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -139,27 +139,7 @@ export class PgStore extends BasePgStore {
     };
   }
 
-  async getFtMetadataBundle(args: {
-    contractPrincipal: string;
-    locale?: string;
-  }): Promise<DbTokenMetadataLocaleBundle> {
-    return await this.sqlTransaction(async sql => {
-      const tokenIdRes = await sql<{ id: number }[]>`
-        SELECT tokens.id FROM tokens
-        INNER JOIN smart_contracts ON tokens.smart_contract_id = smart_contracts.id
-        WHERE smart_contracts.principal = ${args.contractPrincipal}
-      `;
-      if (tokenIdRes.count === 0) {
-        throw new TokenNotFoundError();
-      }
-      if (args.locale && !(await this.isTokenLocaleAvailable(tokenIdRes[0].id, args.locale))) {
-        throw new TokenLocaleNotFoundError();
-      }
-      return await this.getTokenMetadataBundle(tokenIdRes[0].id, args.locale);
-    });
-  }
-
-  async getNftMetadataBundle(args: {
+  async getTokenMetadataBundle(args: {
     contractPrincipal: string;
     tokenNumber: number;
     locale?: string;
@@ -178,7 +158,7 @@ export class PgStore extends BasePgStore {
       if (args.locale && !(await this.isTokenLocaleAvailable(tokenIdRes[0].id, args.locale))) {
         throw new TokenLocaleNotFoundError();
       }
-      return await this.getTokenMetadataBundle(tokenIdRes[0].id, args.locale);
+      return await this.getTokenMetadataBundleInternal(tokenIdRes[0].id, args.locale);
     });
   }
 
@@ -409,7 +389,7 @@ export class PgStore extends BasePgStore {
     return tokenLocale.count !== 0;
   }
 
-  private async getTokenMetadataBundle(
+  private async getTokenMetadataBundleInternal(
     tokenId: number,
     locale?: string
   ): Promise<DbTokenMetadataLocaleBundle> {

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -70,9 +70,13 @@ export class PgStore extends BasePgStore {
     return result[0];
   }
 
-  async getSmartContract(args: { id: number }): Promise<DbSmartContract | undefined> {
+  async getSmartContract(
+    args: { id: number } | { principal: string }
+  ): Promise<DbSmartContract | undefined> {
     const result = await this.sql<DbSmartContract[]>`
-      SELECT ${this.sql(SMART_CONTRACTS_COLUMNS)} FROM smart_contracts WHERE id = ${args.id}
+      SELECT ${this.sql(SMART_CONTRACTS_COLUMNS)}
+      FROM smart_contracts
+      WHERE ${'id' in args ? this.sql`id = ${args.id}` : this.sql`principal = ${args.principal}`}
     `;
     if (result.count === 0) {
       return undefined;

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -122,7 +122,7 @@ export class PgStore extends BasePgStore {
         type: args.type,
       });
     }
-    return this.insertAndEnqueueTokensInternal(tokenValues);
+    return this.insertAndEnqueueTokenArray(tokenValues);
   }
 
   async getToken(args: { id: number }): Promise<DbToken | undefined> {
@@ -379,7 +379,7 @@ export class PgStore extends BasePgStore {
     `;
   }
 
-  private async insertAndEnqueueTokensInternal(tokenValues: DbTokenInsert[]): Promise<DbJob[]> {
+  async insertAndEnqueueTokenArray(tokenValues: DbTokenInsert[]): Promise<DbJob[]> {
     return this.sql<DbJob[]>`
       WITH token_inserts AS (
         INSERT INTO tokens ${this.sql(tokenValues)}

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -43,7 +43,7 @@ export type DbSmartContract = {
   abi: string;
   tx_id: string;
   block_height: number;
-  token_count?: number;
+  token_count?: bigint;
   created_at: string;
   updated_at?: string;
 };
@@ -51,14 +51,14 @@ export type DbSmartContract = {
 export type DbTokenInsert = {
   smart_contract_id: number;
   type: DbTokenType;
-  token_number: number;
+  token_number: PgNumeric;
 };
 
 export type DbToken = {
   id: number;
   smart_contract_id: number;
   type: DbTokenType;
-  token_number: number;
+  token_number: bigint;
   update_mode: DbTokenUpdateMode;
   ttl?: number;
   uri?: string;
@@ -99,7 +99,7 @@ export type DbNftInsert = {
 
 export type DbSftInsert = {
   decimals: number | null;
-  total_supply: number | null;
+  total_supply: PgNumeric | null;
   uri: string | null;
 };
 

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -98,8 +98,6 @@ export type DbNftInsert = {
 };
 
 export type DbSftInsert = {
-  name: string | null;
-  symbol: string | null;
   decimals: number | null;
   total_supply: number | null;
   uri: string | null;

--- a/src/token-processor/blockchain-api/blockchain-smart-contract-monitor.ts
+++ b/src/token-processor/blockchain-api/blockchain-smart-contract-monitor.ts
@@ -28,8 +28,10 @@ type PgSmartContractPayloadLogType = Static<typeof PgSmartContractLogPayload>;
 
 /**
  * Listens for postgres notifications emitted from the API database when new contracts are deployed
- * or contract logs are registered. It will analyze each of them to determine if they're new token
- * contracts that need indexing or SIP-019 notifications that call for a token metadata refresh.
+ * or contract logs are registered. It will analyze each of them to determine if:
+ * - A new token contract needs indexing
+ * - A SIP-019 notifications calls for a token metadata refresh
+ * - A SIP-013 mint event declared a new SFT that needs metadata processing
  */
 export class BlockchainSmartContractMonitor {
   private readonly db: PgStore;

--- a/src/token-processor/blockchain-api/blockchain-smart-contract-monitor.ts
+++ b/src/token-processor/blockchain-api/blockchain-smart-contract-monitor.ts
@@ -136,7 +136,7 @@ export class BlockchainSmartContractMonitor {
           {
             smart_contract_id: contract.id,
             type: DbTokenType.sft,
-            token_number: Number(mint.tokenId),
+            token_number: mint.tokenId.toString(),
           },
         ]);
         logger.info(

--- a/src/token-processor/util/metadata-helpers.ts
+++ b/src/token-processor/util/metadata-helpers.ts
@@ -125,7 +125,7 @@ export async function fetchAllMetadataLocalesFromBaseUri(
  * @param locale - locale to apply
  * @returns token specific uri string
  */
-export function getTokenSpecificUri(uri: string, tokenNumber: number, locale?: string): string {
+export function getTokenSpecificUri(uri: string, tokenNumber: bigint, locale?: string): string {
   const tokenNumStr = tokenNumber.toString();
   const localeStr = locale ?? '';
   return (

--- a/src/token-processor/util/sip-validation.ts
+++ b/src/token-processor/util/sip-validation.ts
@@ -346,6 +346,7 @@ export function getContractLogMetadataUpdateNotification(
 }
 
 export type SftMintEvent = {
+  contractId: string;
   tokenId: bigint;
   amount: bigint;
   recipient: string;
@@ -364,6 +365,7 @@ export function getContractLogSftMintEvent(log: BlockchainDbContractLog): SftMin
     const amount = (value.data['amount'] as UIntCV).value;
 
     const event: SftMintEvent = {
+      contractId: log.contract_identifier,
       tokenId: tokenId,
       amount: amount,
       recipient: recipient,

--- a/src/token-processor/util/sip-validation.ts
+++ b/src/token-processor/util/sip-validation.ts
@@ -221,7 +221,6 @@ export function getSmartContractSip(abi: ClarityAbi): DbSipNumber | undefined {
   if (!abi) {
     return;
   }
-  // TODO: Will stacks.js support SFTs?
   if (abiContains(abi, SftTraitFunctions)) {
     return DbSipNumber.sip013;
   }

--- a/src/token-processor/util/sip-validation.ts
+++ b/src/token-processor/util/sip-validation.ts
@@ -252,6 +252,21 @@ function findFunction(fun: ClarityAbiFunction, functionList: ClarityAbiFunction[
   return found !== undefined;
 }
 
+function stringFromValue(value: ClarityValue): string {
+  switch (value.type) {
+    case ClarityType.Buffer:
+      return value.buffer.toString('utf8');
+    case ClarityType.StringASCII:
+    case ClarityType.StringUTF8:
+      return value.data;
+    case ClarityType.PrincipalContract:
+    case ClarityType.PrincipalStandard:
+      return principalToString(value);
+    default:
+      throw new Error('Invalid clarity value');
+  }
+}
+
 type TokenClass = 'ft' | 'nft' | 'sft';
 
 type MetadataUpdateMode = 'standard' | 'frozen' | 'dynamic';
@@ -271,21 +286,6 @@ export type TokenMetadataUpdateNotification = {
 export function getContractLogMetadataUpdateNotification(
   log: BlockchainDbContractLog
 ): TokenMetadataUpdateNotification | undefined {
-  const stringFromValue = (value: ClarityValue): string => {
-    switch (value.type) {
-      case ClarityType.Buffer:
-        return value.buffer.toString('utf8');
-      case ClarityType.StringASCII:
-      case ClarityType.StringUTF8:
-        return value.data;
-      case ClarityType.PrincipalContract:
-      case ClarityType.PrincipalStandard:
-        return principalToString(value);
-      default:
-        throw new Error('Invalid clarity value');
-    }
-  };
-
   try {
     // Validate that we have the correct SIP-019 payload structure.
     const value = hexToCV(log.value) as TupleCV;
@@ -341,6 +341,35 @@ export function getContractLogMetadataUpdateNotification(
       update_mode: updateMode,
       ttl: ttl,
     };
+  } catch (error) {
+    return;
+  }
+}
+
+export type SftMintEvent = {
+  tokenId: bigint;
+  amount: bigint;
+  recipient: string;
+};
+
+export function getContractLogSftMintEvent(log: BlockchainDbContractLog): SftMintEvent | undefined {
+  try {
+    // Validate that we have the correct SIP-013 `sft-mint` payload structure.
+    const value = hexToCV(log.value) as TupleCV;
+    const type = stringFromValue(value.data.type);
+    if (type !== 'sft-mint') {
+      return;
+    }
+    const recipient = stringFromValue(value.data['recipient']);
+    const tokenId = (value.data['token-id'] as UIntCV).value;
+    const amount = (value.data['amount'] as UIntCV).value;
+
+    const event: SftMintEvent = {
+      tokenId: tokenId,
+      amount: amount,
+      recipient: recipient,
+    };
+    return event;
   } catch (error) {
     return;
   }

--- a/tests/blockchain-smart-contract-monitor.test.ts
+++ b/tests/blockchain-smart-contract-monitor.test.ts
@@ -266,9 +266,9 @@ describe('BlockchainSmartContractMonitor', () => {
       block_height: 1,
     };
     await db.insertAndEnqueueSmartContract({ values });
-    await db.insertAndEnqueueTokens({
+    await db.insertAndEnqueueSequentialTokens({
       smart_contract_id: 1,
-      token_count: 3, // 3 tokens
+      token_count: 3n, // 3 tokens
       type: DbTokenType.nft,
     });
     // Mark jobs as done to test
@@ -317,9 +317,9 @@ describe('BlockchainSmartContractMonitor', () => {
       block_height: 1,
     };
     await db.insertAndEnqueueSmartContract({ values });
-    await db.insertAndEnqueueTokens({
+    await db.insertAndEnqueueSequentialTokens({
       smart_contract_id: 1,
-      token_count: 3, // 3 tokens
+      token_count: 3n, // 3 tokens
       type: DbTokenType.nft,
     });
     // Mark jobs as done to test
@@ -393,9 +393,9 @@ describe('BlockchainSmartContractMonitor', () => {
       block_height: 1,
     };
     await db.insertAndEnqueueSmartContract({ values });
-    await db.insertAndEnqueueTokens({
+    await db.insertAndEnqueueSequentialTokens({
       smart_contract_id: 1,
-      token_count: 1,
+      token_count: 1n,
       type: DbTokenType.nft,
     });
     // Mark jobs as done to test
@@ -449,9 +449,9 @@ describe('BlockchainSmartContractMonitor', () => {
       block_height: 1,
     };
     await db.insertAndEnqueueSmartContract({ values });
-    await db.insertAndEnqueueTokens({
+    await db.insertAndEnqueueSequentialTokens({
       smart_contract_id: 1,
-      token_count: 1,
+      token_count: 1n,
       type: DbTokenType.nft,
     });
     // Mark jobs as done to test
@@ -529,6 +529,6 @@ describe('BlockchainSmartContractMonitor', () => {
 
     const token = await db.getToken({ id: 1 });
     expect(token?.type).toBe(DbTokenType.sft);
-    expect(token?.token_number).toBe(3);
+    expect(token?.token_number).toBe('3');
   });
 });

--- a/tests/ft.test.ts
+++ b/tests/ft.test.ts
@@ -29,9 +29,9 @@ describe('FT routes', () => {
       block_height: 1,
     };
     await db.insertAndEnqueueSmartContract({ values });
-    await db.insertAndEnqueueTokens({
+    await db.insertAndEnqueueSequentialTokens({
       smart_contract_id: 1,
-      token_count: 1,
+      token_count: 1n,
       type: DbTokenType.ft,
     });
   };
@@ -64,7 +64,7 @@ describe('FT routes', () => {
           name: 'hello-world',
           symbol: 'HELLO',
           decimals: 6,
-          total_supply: 1,
+          total_supply: '1',
           uri: 'http://test.com/uri.json',
         },
         metadataLocales: [
@@ -101,7 +101,7 @@ describe('FT routes', () => {
           name: 'hello-world',
           symbol: 'HELLO',
           decimals: 6,
-          total_supply: 1,
+          total_supply: '1',
           uri: 'http://test.com/uri.json',
         },
       },
@@ -129,7 +129,7 @@ describe('FT routes', () => {
           name: 'hello-world',
           symbol: 'HELLO',
           decimals: 6,
-          total_supply: 1,
+          total_supply: '1',
           uri: 'http://test.com/uri.json',
         },
         metadataLocales: [

--- a/tests/job-queue.test.ts
+++ b/tests/job-queue.test.ts
@@ -1,11 +1,13 @@
+import * as postgres from 'postgres';
 import { ENV } from '../src/env';
 import { PgStore } from '../src/pg/pg-store';
 import { DbJob, DbJobStatus, DbSipNumber, DbSmartContractInsert } from '../src/pg/types';
 import { JobQueue } from '../src/token-processor/queue/job-queue';
 import { cycleMigrations } from '../src/pg/migrations';
+import { PgBlockchainApiStore } from '../src/pg/blockchain-api/pg-blockchain-api-store';
 
 class TestJobQueue extends JobQueue {
-  constructor(args: { db: PgStore }) {
+  constructor(args: { db: PgStore; apiDb: PgBlockchainApiStore }) {
     super(args);
     this['isRunning'] = true; // Simulate a running queue.
   }
@@ -25,7 +27,7 @@ describe('JobQueue', () => {
     ENV.PGDATABASE = 'postgres';
     db = await PgStore.connect({ skipMigrations: true });
     await cycleMigrations();
-    queue = new TestJobQueue({ db });
+    queue = new TestJobQueue({ db, apiDb: new PgBlockchainApiStore(postgres()) });
   });
 
   afterEach(async () => {

--- a/tests/metadata-helpers.test.ts
+++ b/tests/metadata-helpers.test.ts
@@ -208,16 +208,16 @@ describe('Metadata Helpers', () => {
   test('replace URI string tokens', () => {
     const uri1 =
       'https://ipfs.io/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn/$TOKEN_ID.json';
-    expect(getTokenSpecificUri(uri1, 7)).toBe(
+    expect(getTokenSpecificUri(uri1, 7n)).toBe(
       'https://ipfs.io/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn/7.json'
     );
     const uri2 = 'https://ipfs.io/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn/{id}.json';
-    expect(getTokenSpecificUri(uri2, 7)).toBe(
+    expect(getTokenSpecificUri(uri2, 7n)).toBe(
       'https://ipfs.io/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn/7.json'
     );
     const uri3 =
       'https://ipfs.io/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn/{id}-{locale}.json';
-    expect(getTokenSpecificUri(uri3, 7, 'es')).toBe(
+    expect(getTokenSpecificUri(uri3, 7n, 'es')).toBe(
       'https://ipfs.io/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn/7-es.json'
     );
   });

--- a/tests/nft.test.ts
+++ b/tests/nft.test.ts
@@ -29,9 +29,9 @@ describe('NFT routes', () => {
       block_height: 1,
     };
     await db.insertAndEnqueueSmartContract({ values });
-    await db.insertAndEnqueueTokens({
+    await db.insertAndEnqueueSequentialTokens({
       smart_contract_id: 1,
-      token_count: 1,
+      token_count: 1n,
       type: DbTokenType.nft,
     });
   };
@@ -64,7 +64,7 @@ describe('NFT routes', () => {
           name: 'hello-world',
           symbol: null,
           decimals: null,
-          total_supply: 1,
+          total_supply: '1',
           uri: 'http://test.com/uri.json',
         },
         metadataLocales: [
@@ -101,7 +101,7 @@ describe('NFT routes', () => {
           name: 'hello-world',
           symbol: null,
           decimals: null,
-          total_supply: 1,
+          total_supply: '1',
           uri: 'http://test.com/uri.json',
         },
       },
@@ -123,7 +123,7 @@ describe('NFT routes', () => {
           name: 'hello-world',
           symbol: null,
           decimals: null,
-          total_supply: 1,
+          total_supply: '1',
           uri: 'http://test.com/uri.json',
         },
         metadataLocales: [

--- a/tests/process-smart-contract-job.test.ts
+++ b/tests/process-smart-contract-job.test.ts
@@ -201,9 +201,9 @@ describe('ProcessSmartContractJob', () => {
     expect(tokens.count).toBe(2);
     expect(tokens[0].type).toBe(DbTokenType.sft);
     expect(tokens[0].smart_contract_id).toBe(1);
-    expect(tokens[0].token_number).toBe(3);
+    expect(tokens[0].token_number).toBe('3');
     expect(tokens[1].type).toBe(DbTokenType.sft);
     expect(tokens[1].smart_contract_id).toBe(1);
-    expect(tokens[1].token_number).toBe(7);
+    expect(tokens[1].token_number).toBe('7');
   });
 });

--- a/tests/process-smart-contract-job.test.ts
+++ b/tests/process-smart-contract-job.test.ts
@@ -1,4 +1,5 @@
-import { cvToHex, uintCV } from '@stacks/transactions';
+import * as postgres from 'postgres';
+import { bufferCV, cvToHex, tupleCV, uintCV } from '@stacks/transactions';
 import { MockAgent, setGlobalDispatcher } from 'undici';
 import { PgStore } from '../src/pg/pg-store';
 import {
@@ -11,6 +12,39 @@ import {
 import { ProcessSmartContractJob } from '../src/token-processor/queue/job/process-smart-contract-job';
 import { ENV } from '../src/env';
 import { cycleMigrations } from '../src/pg/migrations';
+import {
+  BlockchainDbContractLog,
+  PgBlockchainApiStore,
+} from '../src/pg/blockchain-api/pg-blockchain-api-store';
+
+class MockPgBlockchainApiStore extends PgBlockchainApiStore {
+  private contractLogs?: BlockchainDbContractLog[];
+
+  constructor(contractLogs?: BlockchainDbContractLog[]) {
+    super(postgres());
+    this.contractLogs = contractLogs;
+  }
+
+  getSmartContractLogsByContractCursor(args: {
+    contractId: string;
+  }): AsyncIterable<BlockchainDbContractLog[]> {
+    const logs = this.contractLogs ?? [];
+    const iterable: AsyncIterable<BlockchainDbContractLog[]> = {
+      [Symbol.asyncIterator]: (): AsyncIterator<BlockchainDbContractLog[], any, undefined> => {
+        return {
+          next: () => {
+            if (logs.length) {
+              const value = logs.shift() as BlockchainDbContractLog;
+              return Promise.resolve({ value: [value], done: false });
+            }
+            return Promise.resolve({ value: [] as BlockchainDbContractLog[], done: true });
+          },
+        };
+      },
+    };
+    return iterable;
+  }
+}
 
 describe('ProcessSmartContractJob', () => {
   let db: PgStore;
@@ -34,7 +68,11 @@ describe('ProcessSmartContractJob', () => {
       block_height: 1,
     };
     const job = await db.insertAndEnqueueSmartContract({ values });
-    const processor = new ProcessSmartContractJob({ db, job });
+    const processor = new ProcessSmartContractJob({
+      db,
+      job,
+      apiDb: new MockPgBlockchainApiStore(),
+    });
     await processor.work();
 
     const tokens = await db.sql<DbToken[]>`SELECT ${db.sql(TOKENS_COLUMNS)} FROM tokens`;
@@ -66,7 +104,11 @@ describe('ProcessSmartContractJob', () => {
       block_height: 1,
     };
     const job = await db.insertAndEnqueueSmartContract({ values });
-    const processor = new ProcessSmartContractJob({ db, job });
+    const processor = new ProcessSmartContractJob({
+      db,
+      job,
+      apiDb: new MockPgBlockchainApiStore(),
+    });
     await processor.work();
 
     const tokens = await db.sql<DbToken[]>`SELECT ${db.sql(TOKENS_COLUMNS)} FROM tokens`;
@@ -98,10 +140,70 @@ describe('ProcessSmartContractJob', () => {
       block_height: 1,
     };
     const job = await db.insertAndEnqueueSmartContract({ values });
-    const processor = new ProcessSmartContractJob({ db, job });
+    const processor = new ProcessSmartContractJob({
+      db,
+      job,
+      apiDb: new MockPgBlockchainApiStore(),
+    });
     await processor.work();
 
     const tokens = await db.sql<DbToken[]>`SELECT ${db.sql(TOKENS_COLUMNS)} FROM tokens`;
     expect(tokens.count).toBe(0);
+  });
+
+  test('enqueues minted tokens for SFT contract', async () => {
+    const address = 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9';
+    const contractId = `${address}.key-alex-autoalex-v1`;
+
+    const values: DbSmartContractInsert = {
+      principal: contractId,
+      sip: DbSipNumber.sip013,
+      abi: '"some"',
+      tx_id: '0x123456',
+      block_height: 1,
+    };
+    const job = await db.insertAndEnqueueSmartContract({ values });
+
+    // Create mint events.
+    const event1: BlockchainDbContractLog = {
+      contract_identifier: contractId,
+      sender_address: address,
+      value: cvToHex(
+        tupleCV({
+          type: bufferCV(Buffer.from('sft-mint')),
+          recipient: bufferCV(Buffer.from(address)),
+          'token-id': uintCV(3),
+          amount: uintCV(1000),
+        })
+      ),
+    };
+    const event2: BlockchainDbContractLog = {
+      contract_identifier: contractId,
+      sender_address: address,
+      value: cvToHex(
+        tupleCV({
+          type: bufferCV(Buffer.from('sft-mint')),
+          recipient: bufferCV(Buffer.from(address)),
+          'token-id': uintCV(7),
+          amount: uintCV(2000),
+        })
+      ),
+    };
+
+    const processor = new ProcessSmartContractJob({
+      db,
+      job,
+      apiDb: new MockPgBlockchainApiStore([event1, event2]),
+    });
+    await processor.work();
+
+    const tokens = await db.sql<DbToken[]>`SELECT ${db.sql(TOKENS_COLUMNS)} FROM tokens`;
+    expect(tokens.count).toBe(2);
+    expect(tokens[0].type).toBe(DbTokenType.sft);
+    expect(tokens[0].smart_contract_id).toBe(1);
+    expect(tokens[0].token_number).toBe(3);
+    expect(tokens[1].type).toBe(DbTokenType.sft);
+    expect(tokens[1].smart_contract_id).toBe(1);
+    expect(tokens[1].token_number).toBe(7);
   });
 });

--- a/tests/process-token-job.test.ts
+++ b/tests/process-token-job.test.ts
@@ -185,7 +185,7 @@ describe('ProcessTokenJob', () => {
 
       await new ProcessTokenJob({ db, job: tokenJob }).work();
 
-      const bundle = await db.getNftMetadataBundle({
+      const bundle = await db.getTokenMetadataBundle({
         contractPrincipal: 'ABCD.test-nft',
         tokenNumber: 1,
       });
@@ -297,7 +297,7 @@ describe('ProcessTokenJob', () => {
 
       await new ProcessTokenJob({ db, job: tokenJob }).work();
 
-      const bundle = await db.getNftMetadataBundle({
+      const bundle = await db.getTokenMetadataBundle({
         contractPrincipal: 'ABCD.test-nft',
         tokenNumber: 1,
       });
@@ -308,7 +308,7 @@ describe('ProcessTokenJob', () => {
       expect(bundle?.metadataLocale?.metadata.l10n_uri).toBe('http://m.io/1.json');
 
       // Make sure localization overrides work correctly
-      const mexicanBundle = await db.getNftMetadataBundle({
+      const mexicanBundle = await db.getTokenMetadataBundle({
         contractPrincipal: 'ABCD.test-nft',
         tokenNumber: 1,
         locale: 'es-MX',
@@ -395,7 +395,7 @@ describe('ProcessTokenJob', () => {
       // Process once
       await new ProcessTokenJob({ db, job: tokenJob }).work();
 
-      const bundle1 = await db.getNftMetadataBundle({
+      const bundle1 = await db.getTokenMetadataBundle({
         contractPrincipal: 'ABCD.test-nft',
         tokenNumber: 1,
       });
@@ -439,7 +439,7 @@ describe('ProcessTokenJob', () => {
       await db.updateJobStatus({ id: tokenJob.id, status: DbJobStatus.pending });
       await new ProcessTokenJob({ db, job: tokenJob }).work();
 
-      const bundle2 = await db.getNftMetadataBundle({
+      const bundle2 = await db.getTokenMetadataBundle({
         contractPrincipal: 'ABCD.test-nft',
         tokenNumber: 1,
       });
@@ -494,7 +494,7 @@ describe('ProcessTokenJob', () => {
 
       await new ProcessTokenJob({ db, job: tokenJob }).work();
 
-      const bundle = await db.getNftMetadataBundle({
+      const bundle = await db.getTokenMetadataBundle({
         contractPrincipal: 'ABCD.test-nft',
         tokenNumber: 1,
       });

--- a/tests/process-token-job.test.ts
+++ b/tests/process-token-job.test.ts
@@ -39,9 +39,9 @@ describe('ProcessTokenJob', () => {
         block_height: 1,
       };
       await db.insertAndEnqueueSmartContract({ values });
-      [tokenJob] = await db.insertAndEnqueueTokens({
+      [tokenJob] = await db.insertAndEnqueueSequentialTokens({
         smart_contract_id: 1,
-        token_count: 1,
+        token_count: 1n,
         type: DbTokenType.ft,
       });
     });
@@ -123,9 +123,9 @@ describe('ProcessTokenJob', () => {
         block_height: 1,
       };
       await db.insertAndEnqueueSmartContract({ values });
-      [tokenJob] = await db.insertAndEnqueueTokens({
+      [tokenJob] = await db.insertAndEnqueueSequentialTokens({
         smart_contract_id: 1,
-        token_count: 1,
+        token_count: 1n,
         type: DbTokenType.nft,
       });
     });
@@ -520,7 +520,7 @@ describe('ProcessTokenJob', () => {
         {
           smart_contract_id: 1,
           type: DbTokenType.sft,
-          token_number: 1,
+          token_number: '1',
         },
       ]);
     });

--- a/tests/process-token-job.test.ts
+++ b/tests/process-token-job.test.ts
@@ -501,4 +501,73 @@ describe('ProcessTokenJob', () => {
       expect(bundle?.metadataLocale).toBeUndefined();
     });
   });
+
+  describe('SFT', () => {
+    const address = 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9';
+    const contractId = 'key-alex-autoalex-v1';
+    let tokenJob: DbJob;
+
+    beforeEach(async () => {
+      const values: DbSmartContractInsert = {
+        principal: `${address}.${contractId}`,
+        sip: DbSipNumber.sip013,
+        abi: '"some"',
+        tx_id: '0x123456',
+        block_height: 1,
+      };
+      await db.insertAndEnqueueSmartContract({ values });
+      [tokenJob] = await db.insertAndEnqueueTokenArray([
+        {
+          smart_contract_id: 1,
+          type: DbTokenType.sft,
+          token_number: 1,
+        },
+      ]);
+    });
+
+    test('parses SFT info', async () => {
+      const agent = new MockAgent();
+      agent.disableNetConnect();
+      const interceptor = agent.get(
+        `http://${ENV.STACKS_NODE_RPC_HOST}:${ENV.STACKS_NODE_RPC_PORT}`
+      );
+      interceptor
+        .intercept({
+          path: `/v2/contracts/call-read/${address}/${contractId}/get-token-uri`,
+          method: 'POST',
+        })
+        .reply(200, {
+          okay: true,
+          result: cvToHex(noneCV()), // We'll do that in another test
+        });
+      interceptor
+        .intercept({
+          path: `/v2/contracts/call-read/${address}/${contractId}/get-decimals`,
+          method: 'POST',
+        })
+        .reply(200, {
+          okay: true,
+          result: cvToHex(uintCV(6)),
+        });
+      interceptor
+        .intercept({
+          path: `/v2/contracts/call-read/${address}/${contractId}/get-total-supply`,
+          method: 'POST',
+        })
+        .reply(200, {
+          okay: true,
+          result: cvToHex(uintCV(200200200)),
+        });
+      setGlobalDispatcher(agent);
+
+      const processor = new ProcessTokenJob({ db, job: tokenJob });
+      await processor.work();
+
+      const token = await db.getToken({ id: 1 });
+      expect(token).not.toBeUndefined();
+      expect(token?.uri).toBeNull();
+      expect(token?.decimals).toBe(6);
+      expect(token?.total_supply).toBe(200200200n);
+    });
+  });
 });

--- a/tests/sft.test.ts
+++ b/tests/sft.test.ts
@@ -1,0 +1,208 @@
+import { ENV } from '../src/env';
+import { cycleMigrations } from '../src/pg/migrations';
+import { PgStore } from '../src/pg/pg-store';
+import { DbSipNumber, DbSmartContractInsert, DbTokenType } from '../src/pg/types';
+import { startTestApiServer, TestFastifyServer } from './helpers';
+
+describe('SFT routes', () => {
+  let db: PgStore;
+  let fastify: TestFastifyServer;
+
+  beforeEach(async () => {
+    ENV.PGDATABASE = 'postgres';
+    db = await PgStore.connect({ skipMigrations: true });
+    fastify = await startTestApiServer(db);
+    await cycleMigrations();
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+    await db.close();
+  });
+
+  const enqueueToken = async () => {
+    const address = 'SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9';
+    const contractId = 'key-alex-autoalex-v1';
+    const values: DbSmartContractInsert = {
+      principal: `${address}.${contractId}`,
+      sip: DbSipNumber.sip013,
+      abi: '"some"',
+      tx_id: '0x123456',
+      block_height: 1,
+    };
+    await db.insertAndEnqueueSmartContract({ values });
+    await db.insertAndEnqueueTokenArray([
+      {
+        smart_contract_id: 1,
+        type: DbTokenType.sft,
+        token_number: 1,
+      },
+    ]);
+  };
+
+  test('token not found', async () => {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/sft/SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.key-alex-autoalex-v1/1',
+    });
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toStrictEqual({ error: 'Token not found' });
+  });
+
+  test('token not processed', async () => {
+    await enqueueToken();
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/sft/SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.key-alex-autoalex-v1/1',
+    });
+    expect(response.statusCode).toBe(422);
+    expect(response.json()).toStrictEqual({ error: 'Token metadata fetch in progress' });
+  });
+
+  test('locale not found', async () => {
+    await enqueueToken();
+    await db.updateProcessedTokenWithMetadata({
+      id: 1,
+      values: {
+        token: {
+          name: null,
+          symbol: null,
+          decimals: 6,
+          total_supply: 200,
+          uri: 'http://test.com/uri.json',
+        },
+        metadataLocales: [
+          {
+            metadata: {
+              sip: 16,
+              token_id: 1,
+              name: 'key-alex-autoalex-v1',
+              l10n_locale: 'en',
+              l10n_uri: null,
+              l10n_default: true,
+              description: 'test',
+              image: null,
+              cached_image: null,
+            },
+          },
+        ],
+      },
+    });
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/sft/SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.key-alex-autoalex-v1/1?locale=es',
+    });
+    expect(response.statusCode).toBe(422);
+    expect(response.json()).toStrictEqual({ error: 'Locale not found' });
+  });
+
+  test('empty metadata locales', async () => {
+    await enqueueToken();
+    await db.updateProcessedTokenWithMetadata({
+      id: 1,
+      values: {
+        token: {
+          name: 'key-alex-autoalex-v1',
+          symbol: null,
+          decimals: 6,
+          total_supply: 1,
+          uri: 'http://test.com/uri.json',
+        },
+      },
+    });
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/sft/SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.key-alex-autoalex-v1/1',
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toStrictEqual({
+      decimals: 6,
+      total_supply: '1',
+      token_uri: 'http://test.com/uri.json',
+    });
+  });
+
+  test('valid SFT metadata', async () => {
+    await enqueueToken();
+    await db.updateProcessedTokenWithMetadata({
+      id: 1,
+      values: {
+        token: {
+          name: null,
+          symbol: null,
+          decimals: 6,
+          total_supply: 200,
+          uri: 'http://test.com/uri.json',
+        },
+        metadataLocales: [
+          {
+            metadata: {
+              sip: 16,
+              token_id: 1,
+              name: 'key-alex-autoalex-v1',
+              l10n_locale: 'en',
+              l10n_uri: null,
+              l10n_default: true,
+              description: 'test',
+              image: null,
+              cached_image: null,
+            },
+            attributes: [
+              {
+                trait_type: 'strength',
+                display_type: 'number',
+                value: JSON.stringify(105),
+              },
+              {
+                trait_type: 'powers',
+                display_type: 'array',
+                value: JSON.stringify([1, 2, 4]),
+              },
+            ],
+            properties: [
+              {
+                name: 'prop1',
+                value: JSON.stringify('ABC'),
+              },
+              {
+                name: 'prop2',
+                value: JSON.stringify(1),
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/sft/SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.key-alex-autoalex-v1/1',
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toStrictEqual({
+      token_uri: 'http://test.com/uri.json',
+      decimals: 6,
+      total_supply: '200',
+      metadata: {
+        sip: 16,
+        description: 'test',
+        name: 'key-alex-autoalex-v1',
+        attributes: [
+          {
+            display_type: 'number',
+            trait_type: 'strength',
+            value: 105,
+          },
+          {
+            display_type: 'array',
+            trait_type: 'powers',
+            value: [1, 2, 4],
+          },
+        ],
+        properties: {
+          prop1: 'ABC',
+          prop2: 1,
+        },
+      },
+    });
+  });
+});

--- a/tests/sft.test.ts
+++ b/tests/sft.test.ts
@@ -35,7 +35,7 @@ describe('SFT routes', () => {
       {
         smart_contract_id: 1,
         type: DbTokenType.sft,
-        token_number: 1,
+        token_number: '1',
       },
     ]);
   };
@@ -68,7 +68,7 @@ describe('SFT routes', () => {
           name: null,
           symbol: null,
           decimals: 6,
-          total_supply: 200,
+          total_supply: '200',
           uri: 'http://test.com/uri.json',
         },
         metadataLocales: [
@@ -105,7 +105,7 @@ describe('SFT routes', () => {
           name: 'key-alex-autoalex-v1',
           symbol: null,
           decimals: 6,
-          total_supply: 1,
+          total_supply: '1',
           uri: 'http://test.com/uri.json',
         },
       },
@@ -131,7 +131,7 @@ describe('SFT routes', () => {
           name: null,
           symbol: null,
           decimals: 6,
-          total_supply: 200,
+          total_supply: '200',
           uri: 'http://test.com/uri.json',
         },
         metadataLocales: [

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -42,9 +42,9 @@ describe('Status routes', () => {
         block_height: 1,
       },
     });
-    await db.insertAndEnqueueTokens({
+    await db.insertAndEnqueueSequentialTokens({
       smart_contract_id: 1,
-      token_count: 1,
+      token_count: 1n,
       type: DbTokenType.nft,
     });
 


### PR DESCRIPTION
* Detect and process SFT contracts
* Scan API `contract_logs` table to look for SFT mints when processing contract (SIP-013 contracts don't have a direct way to get this information)
* Detect SFT mints through blockchain monitor and enqueue tokens for processing
* Add SFT endpoints to consume metadata

Fixes #56 