### PR TITLE
fix: handle pg disconnections and transaction management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10325,9 +10325,9 @@
       }
     },
     "node_modules/postgres": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.3.1.tgz",
-      "integrity": "sha512-ak/xXToZYwRvQlZIUtLgPUIggz62eIIbPTgxl/Yl4oTu0TgNOd1CrzTCifsvZ89jBwLvnX6+Ky5frp5HzIBoaw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.3.3.tgz",
+      "integrity": "sha512-FGLZOpZSXePRIQu6LJpJUDikzuhplWI80uyyfmKBiljpfO+Z4nuClwpq3/dsRnitxVDsgFN5duJ7eUTaC0meQQ==",
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/porsager"
@@ -23986,9 +23986,9 @@
       }
     },
     "postgres": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.3.1.tgz",
-      "integrity": "sha512-ak/xXToZYwRvQlZIUtLgPUIggz62eIIbPTgxl/Yl4oTu0TgNOd1CrzTCifsvZ89jBwLvnX6+Ky5frp5HzIBoaw=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.3.3.tgz",
+      "integrity": "sha512-FGLZOpZSXePRIQu6LJpJUDikzuhplWI80uyyfmKBiljpfO+Z4nuClwpq3/dsRnitxVDsgFN5duJ7eUTaC0meQQ=="
     },
     "postgres-array": {
       "version": "2.0.0",

--- a/src/pg/postgres-tools/errors.ts
+++ b/src/pg/postgres-tools/errors.ts
@@ -39,6 +39,8 @@ export function isPgConnectionError(error: any): string | false {
       return 'Postgres connection failed due to a DNS lookup error';
     } else if (msg.includes('terminating connection due to administrator command')) {
       return 'Postgres connection closed due to administrator command';
+    } else if (msg.includes('password authentication failed')) {
+      return 'Postgres authentication failed';
     }
   }
   return false;

--- a/src/token-processor/blockchain-api/blockchain-smart-contract-monitor.ts
+++ b/src/token-processor/blockchain-api/blockchain-smart-contract-monitor.ts
@@ -57,7 +57,7 @@ export class BlockchainSmartContractMonitor {
         () => logger.info(`BlockchainSmartContractMonitor connected`)
       );
     } catch (error) {
-      logger.error(`BlockchainSmartContractMonitor unable to connect`, error);
+      logger.error(`BlockchainSmartContractMonitor unable to connect: ${error}`, error);
       throw error;
     }
   }
@@ -78,7 +78,8 @@ export class BlockchainSmartContractMonitor {
               await this.handleSmartContract(messageJson.payload);
             } catch (error) {
               logger.error(
-                `BlockchainSmartContractMonitor error handling contract deploy: ${error}`
+                `BlockchainSmartContractMonitor error handling contract deploy: ${error}`,
+                error
               );
             }
           }
@@ -88,7 +89,10 @@ export class BlockchainSmartContractMonitor {
             try {
               await this.handleSmartContractLog(messageJson.payload);
             } catch (error) {
-              logger.error(`BlockchainSmartContractMonitor error handling contract log: ${error}`);
+              logger.error(
+                `BlockchainSmartContractMonitor error handling contract log: ${error}`,
+                error
+              );
             }
           }
           break;
@@ -97,7 +101,7 @@ export class BlockchainSmartContractMonitor {
             try {
               await this.handleBlock(messageJson.payload);
             } catch (error) {
-              logger.error(`BlockchainSmartContractMonitor error handling block: ${error}`);
+              logger.error(`BlockchainSmartContractMonitor error handling block: ${error}`, error);
             }
           }
           break;

--- a/src/token-processor/blockchain-api/blockchain-smart-contract-monitor.ts
+++ b/src/token-processor/blockchain-api/blockchain-smart-contract-monitor.ts
@@ -77,7 +77,9 @@ export class BlockchainSmartContractMonitor {
             try {
               await this.handleSmartContract(messageJson.payload);
             } catch (error) {
-              logger.error(`BlockchainSmartContractMonitor error handling contract deploy`, error);
+              logger.error(
+                `BlockchainSmartContractMonitor error handling contract deploy: ${error}`
+              );
             }
           }
           break;
@@ -86,7 +88,7 @@ export class BlockchainSmartContractMonitor {
             try {
               await this.handleSmartContractLog(messageJson.payload);
             } catch (error) {
-              logger.error(`BlockchainSmartContractMonitor error handling contract log`, error);
+              logger.error(`BlockchainSmartContractMonitor error handling contract log: ${error}`);
             }
           }
           break;
@@ -95,7 +97,7 @@ export class BlockchainSmartContractMonitor {
             try {
               await this.handleBlock(messageJson.payload);
             } catch (error) {
-              logger.error(`BlockchainSmartContractMonitor error handling block`, error);
+              logger.error(`BlockchainSmartContractMonitor error handling block: ${error}`);
             }
           }
           break;

--- a/src/token-processor/queue/job-queue.ts
+++ b/src/token-processor/queue/job-queue.ts
@@ -85,19 +85,22 @@ export class JobQueue {
     ) {
       return;
     }
-    this.jobIds.add(job.id);
     await this.db.updateJobStatus({ id: job.id, status: DbJobStatus.queued });
+    this.jobIds.add(job.id);
     void this.queue.add(async () => {
-      if (this.isRunning) {
-        if (job.token_id) {
-          await new ProcessTokenJob({ db: this.db, job: job }).work();
-        } else if (job.smart_contract_id) {
-          await new ProcessSmartContractJob({ db: this.db, apiDb: this.apiDb, job: job }).work();
+      try {
+        if (this.isRunning) {
+          if (job.token_id) {
+            await new ProcessTokenJob({ db: this.db, job: job }).work();
+          } else if (job.smart_contract_id) {
+            await new ProcessSmartContractJob({ db: this.db, apiDb: this.apiDb, job: job }).work();
+          }
+        } else {
+          logger.info(`JobQueue cancelling job ${job.id}, queue is now closed`);
         }
-      } else {
-        logger.info(`JobQueue cancelling job ${job.id}, queue is now closed`);
+      } finally {
+        this.jobIds.delete(job.id);
       }
-      this.jobIds.delete(job.id);
     });
   }
 
@@ -141,7 +144,7 @@ export class JobQueue {
         }
         await this.queue.onIdle();
       } catch (error) {
-        logger.error(`JobQueue loop error`, error);
+        logger.error(`JobQueue loop error: ${error}`);
         await timeout(1_000);
       }
     }

--- a/src/token-processor/queue/job/job.ts
+++ b/src/token-processor/queue/job/job.ts
@@ -38,16 +38,13 @@ export abstract class Job {
     let finishedWithError = false;
     const sw = stopwatch();
 
-    // This sql transaction will catch any and all errors that are generated while processing the
-    // job. Each of them were previously tagged as retryable or not retryable so we'll make a
-    // decision here about what to do in each case. If we choose to retry, this queue entry will
-    // simply not be marked as `processed = true` so it can be picked up by the queue at a later
-    // time.
+    // This block will catch any and all errors that are generated while processing the job. Each of
+    // them were previously tagged as retryable or not retryable so we'll make a decision here about
+    // what to do in each case. If we choose to retry, this queue entry will simply not be marked as
+    // `processed = true` so it can be picked up by the queue at a later time.
     try {
-      await this.db.sqlWriteTransaction(async sql => {
-        await this.handler();
-        processingFinished = true;
-      });
+      await this.handler();
+      processingFinished = true;
     } catch (error) {
       if (error instanceof RetryableJobError) {
         const retries = await this.db.increaseJobRetryCount({ id: this.job.id });
@@ -60,7 +57,7 @@ export abstract class Job {
               error.message
             }`
           );
-          await this.db.updateJobStatus({ id: this.job.id, status: DbJobStatus.pending });
+          await this.updateStatus(DbJobStatus.pending);
         } else {
           logger.warn(`Job ${this.description()} max retries reached, giving up: ${error.message}`);
           processingFinished = true;
@@ -75,12 +72,20 @@ export abstract class Job {
     } finally {
       if (processingFinished) {
         const status = finishedWithError ? DbJobStatus.failed : DbJobStatus.done;
-        await this.db.updateJobStatus({
-          id: this.job.id,
-          status: status,
-        });
-        logger.info(`Job ${this.description()} ${status} in ${sw.getElapsed()}ms`);
+        if (await this.updateStatus(status)) {
+          logger.info(`Job ${this.description()} ${status} in ${sw.getElapsed()}ms`);
+        }
       }
+    }
+  }
+
+  private async updateStatus(status: DbJobStatus): Promise<boolean> {
+    try {
+      await this.db.updateJobStatus({ id: this.job.id, status: status });
+      return true;
+    } catch (error) {
+      logger.error(`Job ${this.description()} could not update status to ${status}: ${error}`);
+      return false;
     }
   }
 }

--- a/src/token-processor/queue/job/process-smart-contract-job.ts
+++ b/src/token-processor/queue/job/process-smart-contract-job.ts
@@ -105,14 +105,16 @@ export class ProcessSmartContractJob extends Job {
       );
       return;
     }
-    await this.db.updateSmartContractTokenCount({ id: contract.id, count: tokenCount });
-    logger.info(
-      `ProcessSmartContractJob enqueueing ${tokenCount} tokens for ${this.description()}`
-    );
-    await this.db.insertAndEnqueueSequentialTokens({
-      smart_contract_id: contract.id,
-      token_count: tokenCount,
-      type: dbSipNumberToDbTokenType(contract.sip),
+    await this.db.sqlWriteTransaction(async sql => {
+      logger.info(
+        `ProcessSmartContractJob enqueueing ${tokenCount} tokens for ${this.description()}`
+      );
+      await this.db.updateSmartContractTokenCount({ id: contract.id, count: tokenCount });
+      await this.db.insertAndEnqueueSequentialTokens({
+        smart_contract_id: contract.id,
+        token_count: tokenCount,
+        type: dbSipNumberToDbTokenType(contract.sip),
+      });
     });
   }
 }

--- a/src/token-processor/queue/job/process-token-job.ts
+++ b/src/token-processor/queue/job/process-token-job.ts
@@ -30,17 +30,21 @@ export class ProcessTokenJob extends Job {
   private contract?: DbSmartContract;
 
   async handler(): Promise<void> {
-    if (!this.job.token_id) {
+    const tokenId = this.job.token_id;
+    if (!tokenId) {
       return;
     }
-    const token = await this.db.getToken({ id: this.job.token_id });
-    if (!token) {
-      throw Error(`ProcessTokenJob token not found with id ${this.job.token_id}`);
-    }
-    const contract = await this.db.getSmartContract({ id: token.smart_contract_id });
-    if (!contract) {
-      throw Error(`ProcessTokenJob contract not found with id ${token.smart_contract_id}`);
-    }
+    const [token, contract] = await this.db.sqlTransaction(async sql => {
+      const token = await this.db.getToken({ id: tokenId });
+      if (!token) {
+        throw Error(`ProcessTokenJob token not found with id ${tokenId}`);
+      }
+      const contract = await this.db.getSmartContract({ id: token.smart_contract_id });
+      if (!contract) {
+        throw Error(`ProcessTokenJob contract not found with id ${token.smart_contract_id}`);
+      }
+      return [token, contract];
+    });
     this.token = token;
     this.contract = contract;
 

--- a/tests/job-queue.test.ts
+++ b/tests/job-queue.test.ts
@@ -5,6 +5,7 @@ import { DbJob, DbJobStatus, DbSipNumber, DbSmartContractInsert } from '../src/p
 import { JobQueue } from '../src/token-processor/queue/job-queue';
 import { cycleMigrations } from '../src/pg/migrations';
 import { PgBlockchainApiStore } from '../src/pg/blockchain-api/pg-blockchain-api-store';
+import { MockPgBlockchainApiStore } from './helpers';
 
 class TestJobQueue extends JobQueue {
   constructor(args: { db: PgStore; apiDb: PgBlockchainApiStore }) {
@@ -114,5 +115,28 @@ describe('JobQueue', () => {
     expect((await db.getJob({ id: job1.id }))?.status).toBe('done');
     expect((await db.getJob({ id: job2.id }))?.status).toBe('queued');
     expect((await db.getJob({ id: job3.id }))?.status).toBe('queued');
+  });
+
+  test('pg connection errors are not re-thrown', async () => {
+    const values1: DbSmartContractInsert = {
+      principal: 'ABCD.test-ft',
+      sip: DbSipNumber.sip010,
+      abi: '"some"',
+      tx_id: '0x123456',
+      block_height: 1,
+    };
+    await db.insertAndEnqueueSmartContract({ values: values1 });
+
+    const queue = new JobQueue({ db, apiDb: new MockPgBlockchainApiStore() });
+    const sleep = (time: number) => {
+      return new Promise(resolve => setTimeout(resolve, time));
+    };
+
+    // Close DB and start the queue. If the error is not handled correctly, the test will fail.
+    await db.close();
+    queue.start();
+    // Wait 2 seconds and kill the queue.
+    await sleep(2000);
+    await queue.close();
   });
 });


### PR DESCRIPTION
* Recover gracefully from pg disconnections by clearing failed jobs from queue and letting the queue loop try again for a connection indefinitely
* Remove long-running pg transactions that encompassed the entire token/contract job processing (including metadata fetch). Now, transactions are opened and closed only when required which improves connection reuse on the entire service.

Related to #82 