### PR TITLE
feat: throttle requests to rate limited domains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ WORKDIR /app
 COPY . .
 
 RUN apk add --no-cache --virtual .build-deps git
-RUN npm config set unsafe-perm true && \
-    npm ci && \
+RUN npm ci && \
     npm run build && \
     npm run generate:git-info && \
     npm prune --production

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The
 component constantly listens for the following Stacks Blockchain API events:
 
 * **Smart contract log events**
-    
+
     If a contract `print` event conforms to SIP-019, it finds the affected tokens and marks them for
     metadata refresh.
 
@@ -192,3 +192,7 @@ metadata ingestion.
 This job fetches the metadata JSON object for a single token as well as other relevant properties
 depending on the token type (symbol, decimals, etc.). Once fetched, it parses and ingests this data
 to save it into the local database for API endpoints to return.
+
+If a `429` (Too Many Requests) status code is returned by a hostname used to fetch metadata, the
+service will cease all further requests to it until a reasonable amount of time has passed or until
+the time specified by the host in a `Retry-After` response header.

--- a/migrations/1670264425574_smart-contracts.ts
+++ b/migrations/1670264425574_smart-contracts.ts
@@ -34,12 +34,12 @@ export function up(pgm: MigrationBuilder): void {
       type: 'numeric',
     },
     created_at: {
-      type: 'timestamp',
+      type: 'timestamptz',
       default: pgm.func('(NOW())'),
       notNull: true,
     },
     updated_at: {
-      type: 'timestamp',
+      type: 'timestamptz',
     },
   });
   pgm.createConstraint('smart_contracts', 'smart_contracts_principal_unique', 'UNIQUE(principal)');

--- a/migrations/1670265062169_tokens.ts
+++ b/migrations/1670265062169_tokens.ts
@@ -47,12 +47,12 @@ export function up(pgm: MigrationBuilder): void {
       type: 'numeric',
     },
     created_at: {
-      type: 'timestamp',
+      type: 'timestamptz',
       default: pgm.func('(NOW())'),
       notNull: true,
     },
     updated_at: {
-      type: 'timestamp',
+      type: 'timestamptz',
     },
   });
   pgm.createConstraint(

--- a/migrations/1670266371036_jobs.ts
+++ b/migrations/1670266371036_jobs.ts
@@ -25,12 +25,12 @@ export function up(pgm: MigrationBuilder): void {
       default: 0,
     },
     created_at: {
-      type: 'timestamp',
+      type: 'timestamptz',
       default: pgm.func('(NOW())'),
       notNull: true,
     },
     updated_at: {
-      type: 'timestamp',
+      type: 'timestamptz',
     },
   });
   pgm.createConstraint('jobs', 'jobs_token_id_fk', 'FOREIGN KEY(token_id) REFERENCES tokens(id)');

--- a/migrations/1675368570737_rate-limited-hosts.ts
+++ b/migrations/1675368570737_rate-limited-hosts.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.createTable('rate_limited_hosts', {
+    id: {
+      type: 'serial',
+      primaryKey: true,
+    },
+    hostname: {
+      type: 'text',
+      notNull: true,
+    },
+    created_at: {
+      type: 'timestamp',
+      default: pgm.func('(NOW())'),
+      notNull: true,
+    },
+    retry_after: {
+      type: 'timestamp',
+      notNull: true,
+    },
+  });
+  pgm.createConstraint(
+    'rate_limited_hosts',
+    'rate_limited_hosts_hostname_unique',
+    'UNIQUE(hostname)'
+  );
+  pgm.createIndex('rate_limited_hosts', ['hostname']);
+}

--- a/migrations/1675368570737_rate-limited-hosts.ts
+++ b/migrations/1675368570737_rate-limited-hosts.ts
@@ -14,12 +14,12 @@ export function up(pgm: MigrationBuilder): void {
       notNull: true,
     },
     created_at: {
-      type: 'timestamp',
+      type: 'timestamptz',
       default: pgm.func('(NOW())'),
       notNull: true,
     },
     retry_after: {
-      type: 'timestamp',
+      type: 'timestamptz',
       notNull: true,
     },
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -16088,9 +16088,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.16.0.tgz",
-      "integrity": "sha512-KWBOXNv6VX+oJQhchXieUznEmnJMqgXMbs0xxH2t8q/FUAWSJvOSr/rMaZKnX5RIVq7JDn0JbP4BOnKG2SGXLQ==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.18.0.tgz",
+      "integrity": "sha512-1iVwbhonhFytNdg0P4PqyIAXbdlVZVebtPDvuM36m66mRw4OGrCm2MYynJv/UENFLdP13J1nPVQzVE2zTs1OeA==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -28575,9 +28575,9 @@
       }
     },
     "undici": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.16.0.tgz",
-      "integrity": "sha512-KWBOXNv6VX+oJQhchXieUznEmnJMqgXMbs0xxH2t8q/FUAWSJvOSr/rMaZKnX5RIVq7JDn0JbP4BOnKG2SGXLQ==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.18.0.tgz",
+      "integrity": "sha512-1iVwbhonhFytNdg0P4PqyIAXbdlVZVebtPDvuM36m66mRw4OGrCm2MYynJv/UENFLdP13J1nPVQzVE2zTs1OeA==",
       "requires": {
         "busboy": "^1.6.0"
       }

--- a/src/env.ts
+++ b/src/env.ts
@@ -231,6 +231,10 @@ export function getEnvVars(): Env {
         type: 'number',
         default: 86_400, // 24 hours
       },
+      METADATA_RATE_LIMITED_HOST_RETRY_AFTER: {
+        type: 'number',
+        default: 3600, // 1 hour
+      },
       JOB_QUEUE_CONCURRENCY_LIMIT: {
         type: 'number',
         default: 5,

--- a/src/env.ts
+++ b/src/env.ts
@@ -68,7 +68,9 @@ interface Env {
    */
   METADATA_DYNAMIC_TOKEN_REFRESH_INTERVAL: number;
   /**
-   * xasdfsdf
+   * Time that must elapse between a 429 'Too many requests' response returned by a hostname and the
+   * next request that is sent to it (seconds). This value will be overridden by the `Retry-After`
+   * header returned by the domain, if any.
    */
   METADATA_RATE_LIMITED_HOST_RETRY_AFTER: number;
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -67,6 +67,10 @@ interface Env {
    * hours).
    */
   METADATA_DYNAMIC_TOKEN_REFRESH_INTERVAL: number;
+  /**
+   * xasdfsdf
+   */
+  METADATA_RATE_LIMITED_HOST_RETRY_AFTER: number;
 
   /** Whether or not the `JobQueue` will continue to try retryable failed jobs indefinitely. */
   JOB_QUEUE_STRICT_MODE: boolean;

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -21,6 +21,9 @@ import {
   METADATA_COLUMNS,
   METADATA_ATTRIBUTES_COLUMNS,
   METADATA_PROPERTIES_COLUMNS,
+  DbRateLimitedHostInsert,
+  DbRateLimitedHost,
+  RATE_LIMITED_HOSTS_COLUMNS,
 } from './types';
 import { connectPostgres } from './postgres-tools';
 import { BasePgStore } from './postgres-tools/base-pg-store';
@@ -393,8 +396,29 @@ export class PgStore extends BasePgStore {
       INSERT INTO jobs (token_id) (SELECT id AS token_id FROM token_inserts)
       ON CONFLICT (token_id) WHERE smart_contract_id IS NULL DO
         UPDATE SET updated_at = NOW(), status = 'pending'
-      RETURNING *
+      RETURNING ${this.sql(JOBS_COLUMNS)}
     `;
+  }
+
+  async insertRateLimitedHost(values: DbRateLimitedHostInsert): Promise<DbRateLimitedHost> {
+    const results = await this.sql<DbRateLimitedHost[]>`
+      INSERT INTO rate_limited_hosts ${this.sql(values)}
+      ON CONFLICT ON CONSTRAINT rate_limited_hosts_hostname_unique DO
+        UPDATE SET retry_after = EXCLUDED.retry_after
+      RETURNING ${this.sql(RATE_LIMITED_HOSTS_COLUMNS)}
+    `;
+    return results[0];
+  }
+
+  async getRateLimitedHost(hostname: string): Promise<DbRateLimitedHost | undefined> {
+    const results = await this.sql<DbRateLimitedHost[]>`
+      SELECT ${this.sql(RATE_LIMITED_HOSTS_COLUMNS)}
+      FROM rate_limited_hosts
+      WHERE hostname = ${hostname}
+    `;
+    if (results.count > 0) {
+      return results[0];
+    }
   }
 
   private async isTokenLocaleAvailable(tokenId: number, locale: string): Promise<boolean> {

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -425,6 +425,12 @@ export class PgStore extends BasePgStore {
     }
   }
 
+  async deleteRateLimitedHost(args: { hostname: string }): Promise<void> {
+    await this.sql`
+      DELETE FROM rate_limited_hosts WHERE hostname = ${args.hostname}
+    `;
+  }
+
   private async isTokenLocaleAvailable(tokenId: number, locale: string): Promise<boolean> {
     const tokenLocale = await this.sql<{ id: number }[]>`
       SELECT id FROM metadata

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -85,6 +85,19 @@ export type DbJob = {
   updated_at?: string;
 };
 
+export type DbRateLimitedHostInsert = {
+  hostname: string;
+  // Will be converted into a timestamp upon insert.
+  retry_after: number;
+};
+
+export type DbRateLimitedHost = {
+  id: number;
+  hostname: string;
+  created_at: string;
+  retry_after: string;
+};
+
 export type DbFtInsert = {
   name: string | null;
   symbol: string | null;
@@ -238,3 +251,5 @@ export const METADATA_ATTRIBUTES_COLUMNS = [
 ];
 
 export const METADATA_PROPERTIES_COLUMNS = ['id', 'metadata_id', 'name', 'value'];
+
+export const RATE_LIMITED_HOSTS_COLUMNS = ['id', 'hostname', 'created_at', 'retry_after'];

--- a/src/token-processor/queue/job/process-token-job.ts
+++ b/src/token-processor/queue/job/process-token-job.ts
@@ -4,6 +4,7 @@ import {
   decodeClarityValueToRepr,
   TransactionVersion,
 } from 'stacks-encoding-native-js';
+import { ENV } from '../../../env';
 import { logger } from '../../../logger';
 import { PgNumeric } from '../../../pg/postgres-tools/types';
 import {
@@ -14,8 +15,10 @@ import {
   DbTokenType,
 } from '../../../pg/types';
 import { StacksNodeRpcClient } from '../../stacks-node/stacks-node-rpc-client';
+import { TooManyRequestsHttpError } from '../../util/errors';
 import {
   fetchAllMetadataLocalesFromBaseUri,
+  getFetchableUrl,
   getTokenSpecificUri,
 } from '../../util/metadata-helpers';
 import { Job } from './job';
@@ -55,16 +58,23 @@ export class ProcessTokenJob extends Job {
       senderAddress: senderAddress,
     });
     logger.info(`ProcessTokenJob processing ${this.description()}`);
-    switch (token.type) {
-      case DbTokenType.ft:
-        await this.handleFt(client, token);
-        break;
-      case DbTokenType.nft:
-        await this.handleNft(client, token);
-        break;
-      case DbTokenType.sft:
-        await this.handleSft(client, token);
-        break;
+    try {
+      switch (token.type) {
+        case DbTokenType.ft:
+          await this.handleFt(client, token);
+          break;
+        case DbTokenType.nft:
+          await this.handleNft(client, token);
+          break;
+        case DbTokenType.sft:
+          await this.handleSft(client, token);
+          break;
+      }
+    } catch (error) {
+      if (error instanceof TooManyRequestsHttpError) {
+        await this.saveRateLimitedHost(error);
+      }
+      throw error;
     }
   }
 
@@ -83,8 +93,8 @@ export class ProcessTokenJob extends Job {
   }
 
   private async handleFt(client: StacksNodeRpcClient, token: DbToken) {
+    const uri = await this.getTokenUri(client);
     const name = await client.readStringFromContract('get-name');
-    const uri = await client.readStringFromContract('get-token-uri');
     const symbol = await client.readStringFromContract('get-symbol');
 
     let fDecimals: number | undefined;
@@ -118,9 +128,7 @@ export class ProcessTokenJob extends Job {
   }
 
   private async handleNft(client: StacksNodeRpcClient, token: DbToken) {
-    const uri = await client.readStringFromContract('get-token-uri', [
-      this.uIntCv(token.token_number),
-    ]);
+    const uri = await this.getTokenUri(client, token.token_number);
     let metadataLocales: DbMetadataLocaleInsertBundle[] | undefined;
     if (uri) {
       metadataLocales = await fetchAllMetadataLocalesFromBaseUri(uri, token);
@@ -136,9 +144,8 @@ export class ProcessTokenJob extends Job {
   }
 
   private async handleSft(client: StacksNodeRpcClient, token: DbToken) {
+    const uri = await this.getTokenUri(client, token.token_number);
     const arg = [this.uIntCv(token.token_number)];
-
-    const uri = await client.readStringFromContract('get-token-uri', arg);
 
     let fDecimals: number | undefined;
     const decimals = await client.readUIntFromContract('get-decimals', arg);
@@ -166,6 +173,32 @@ export class ProcessTokenJob extends Job {
       metadataLocales: metadataLocales,
     };
     await this.db.updateProcessedTokenWithMetadata({ id: token.id, values: tokenValues });
+  }
+
+  private async saveRateLimitedHost(error: TooManyRequestsHttpError) {
+    const hostname = error.url.hostname;
+    const retryAfter = error.retryAfter ?? ENV.METADATA_RATE_LIMITED_HOST_RETRY_AFTER;
+    logger.info(`ProcessTokenJob saving rate limited host ${hostname}, retry after ${retryAfter}s`);
+    await this.db.insertRateLimitedHost({ hostname, retry_after: retryAfter });
+  }
+
+  private async getTokenUri(
+    client: StacksNodeRpcClient,
+    tokenNumber?: bigint
+  ): Promise<string | undefined> {
+    const uri = await client.readStringFromContract(
+      'get-token-uri',
+      tokenNumber ? [this.uIntCv(tokenNumber)] : undefined
+    );
+    if (!uri) {
+      return;
+    }
+    const fetchable = getFetchableUrl(uri);
+    const rateLimitedHost = await this.db.getRateLimitedHost(fetchable.hostname);
+    if (rateLimitedHost) {
+      // TODO: check if retry after has elapsed.
+    }
+    return uri;
   }
 
   private uIntCv(n: bigint): ClarityValueUInt {

--- a/src/token-processor/queue/job/process-token-job.ts
+++ b/src/token-processor/queue/job/process-token-job.ts
@@ -201,7 +201,8 @@ export class ProcessTokenJob extends Job {
     const rateLimitedHost = await this.db.getRateLimitedHost({ hostname: fetchable.hostname });
     if (rateLimitedHost) {
       const retryAfter = Date.parse(rateLimitedHost.retry_after);
-      if (retryAfter > Date.now()) {
+      const now = Date.now();
+      if (retryAfter <= now) {
         // Retry-After has passed, we can proceed.
         await this.db.deleteRateLimitedHost({ hostname: fetchable.hostname });
         logger.info(

--- a/src/token-processor/util/errors.ts
+++ b/src/token-processor/util/errors.ts
@@ -35,7 +35,16 @@ export class HttpError extends Error {
   }
 }
 
-export class TooManyRequestsHttpError extends HttpError {}
+export class TooManyRequestsHttpError extends HttpError {
+  public url: URL;
+  public retryAfter?: number;
+  constructor(url: URL, retryAfter?: number) {
+    super(url.toString());
+    this.name = this.constructor.name;
+    this.url = url;
+    this.retryAfter = retryAfter;
+  }
+}
 
 export class JsonParseError extends Error {
   constructor(message: string) {

--- a/src/token-processor/util/errors.ts
+++ b/src/token-processor/util/errors.ts
@@ -1,3 +1,6 @@
+import { errors } from 'undici';
+import { parseRetryAfterResponseHeader } from './helpers';
+
 /** Thrown when fetching metadata exceeds the max allowed byte size */
 export class MetadataSizeExceededError extends Error {
   constructor(message: string) {
@@ -37,12 +40,14 @@ export class HttpError extends Error {
 
 export class TooManyRequestsHttpError extends HttpError {
   public url: URL;
+  /** `Retry-After` header value in seconds, if any. */
   public retryAfter?: number;
-  constructor(url: URL, retryAfter?: number) {
+
+  constructor(url: URL, error: errors.ResponseStatusCodeError) {
     super(url.toString());
     this.name = this.constructor.name;
     this.url = url;
-    this.retryAfter = retryAfter;
+    this.retryAfter = parseRetryAfterResponseHeader(error);
   }
 }
 

--- a/src/token-processor/util/helpers.ts
+++ b/src/token-processor/util/helpers.ts
@@ -1,3 +1,4 @@
+import { errors } from 'undici';
 import { DbSipNumber, DbTokenType } from '../../pg/types';
 
 export function dbSipNumberToDbTokenType(sip: DbSipNumber): DbTokenType {
@@ -29,4 +30,32 @@ export function waiter<T = void>(): Waiter<T> {
     isFinished: false,
   };
   return Object.assign(promise, completer);
+}
+
+/**
+ * Parses a `Retry-After` HTTP header from an undici 429 `ResponseStatusCodeError` error so we can
+ * determine when we can try calling the same host again looking for metadata.
+ * @param error - Original ResponseStatusCodeError
+ * @returns retry-after value in seconds since now
+ */
+export function parseRetryAfterResponseHeader(
+  error: errors.ResponseStatusCodeError
+): number | undefined {
+  if (error.statusCode != 429 || !error.headers || !('retry-after' in error.headers)) {
+    return;
+  }
+  const value = error.headers['retry-after'];
+  if (!value) return;
+
+  // Numerical values e.g. `Retry-After: 120`
+  const nval = Number(value);
+  if (Number.isFinite(nval) && nval > 0) {
+    return nval;
+  }
+
+  // HTTP Date values e.g. `Retry-After: Wed, 21 Oct 2015 07:28:00 GMT`
+  const retryDateMS = Date.parse(value);
+  if (Number.isNaN(retryDateMS)) return;
+  const deltaMS = retryDateMS - Date.now();
+  return deltaMS > 0 ? Math.ceil(deltaMS / 1000) : undefined;
 }

--- a/src/token-processor/util/metadata-helpers.ts
+++ b/src/token-processor/util/metadata-helpers.ts
@@ -1,4 +1,5 @@
 import * as querystring from 'querystring';
+import { IncomingHttpHeaders } from 'http';
 import { Agent, errors, request } from 'undici';
 import {
   DbMetadataAttributeInsert,
@@ -181,6 +182,10 @@ async function parseMetadataForInsertion(
   return inserts;
 }
 
+function parseRetryAfterResponseHeader(error: errors.ResponseStatusCodeError): number | undefined {
+  if (error.headers instanceof IncomingHttpHeaders)
+}
+
 /**
  * Fetches metadata while monitoring timeout and size limits. Throws if any is reached.
  * Taken from https://github.com/node-fetch/node-fetch/issues/1149#issuecomment-840416752
@@ -211,7 +216,8 @@ export async function performSizeAndTimeLimitedMetadataFetch(
     } else if (error instanceof errors.ResponseExceededMaxSizeError) {
       throw new MetadataSizeExceededError(url);
     } else if (error instanceof errors.ResponseStatusCodeError && error.statusCode === 429) {
-      throw new TooManyRequestsHttpError(url);
+      const retryAfter = parseRetryAfterResponseHeader(error);
+      throw new TooManyRequestsHttpError(httpUrl, );
     }
     throw new HttpError(`${url}: ${error}`, error);
   }

--- a/src/token-processor/util/metadata-helpers.ts
+++ b/src/token-processor/util/metadata-helpers.ts
@@ -205,8 +205,7 @@ export async function performSizeAndTimeLimitedMetadataFetch(
     if (
       error instanceof errors.HeadersTimeoutError ||
       error instanceof errors.BodyTimeoutError ||
-      (error as any).code === 'UND_ERR_SOCKET_TIMEOUT' ||
-      (error as any).code === 'UND_ERR_CONNECT_TIMEOUT'
+      error instanceof errors.ConnectTimeoutError
     ) {
       throw new MetadataTimeoutError(url);
     } else if (error instanceof errors.ResponseExceededMaxSizeError) {

--- a/src/token-processor/util/metadata-helpers.ts
+++ b/src/token-processor/util/metadata-helpers.ts
@@ -182,10 +182,6 @@ async function parseMetadataForInsertion(
   return inserts;
 }
 
-function parseRetryAfterResponseHeader(error: errors.ResponseStatusCodeError): number | undefined {
-  if (error.headers instanceof IncomingHttpHeaders)
-}
-
 /**
  * Fetches metadata while monitoring timeout and size limits. Throws if any is reached.
  * Taken from https://github.com/node-fetch/node-fetch/issues/1149#issuecomment-840416752
@@ -216,8 +212,7 @@ export async function performSizeAndTimeLimitedMetadataFetch(
     } else if (error instanceof errors.ResponseExceededMaxSizeError) {
       throw new MetadataSizeExceededError(url);
     } else if (error instanceof errors.ResponseStatusCodeError && error.statusCode === 429) {
-      const retryAfter = parseRetryAfterResponseHeader(error);
-      throw new TooManyRequestsHttpError(httpUrl, );
+      throw new TooManyRequestsHttpError(httpUrl, error);
     }
     throw new HttpError(`${url}: ${error}`, error);
   }


### PR DESCRIPTION
* Save domains that respond with 429 status codes
* Parse the `Retry-After` header and save that date for retries, default to 1 hour if not specified
* Change all `timestamp` columns to `timestamptz` to correctly use and compare pg timestamps
* Upgrade undici to include new error types from https://github.com/nodejs/undici/pull/1888

Fixes #86 